### PR TITLE
Push docker images in CD style

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -31,20 +31,18 @@ tag_and_push_all() {
     else
         TAG=$1
     fi
-    DOCKER_REPO=${GROUP}/${REPO}
-    if [[ "$COMMIT" != "$TAG" ]]; then
-        echo "Tagging docker release"
-        docker tag ${DOCKER_REPO}:${COMMIT} ${DOCKER_REPO}:${TAG}
-    fi
-    push "$DOCKER_REPO:$TAG";
+    for m in ./docker/*/; do
+        REPO=${GROUP}/$(basename $m)
+        if [[ "$COMMIT" != "$TAG" ]]; then
+            docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
+        fi
+        push "$REPO:$TAG";
+    done;
 }
 
-# Always push commit
-tag_and_push_all $COMMIT
-
 # Push snapshot when in master
-if [ "$TRAVIS_BRANCH" == "master" ]; then
-    tag_and_push_all snapshot
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    tag_and_push_all master-${COMMIT:0:8}
 fi;
 
 # Push tag and latest when tagged

--- a/push.sh
+++ b/push.sh
@@ -31,13 +31,12 @@ tag_and_push_all() {
     else
         TAG=$1
     fi
-    for m in ./docker/*/; do
-        REPO=${GROUP}/$(basename $m)
-        if [[ "$COMMIT" != "$TAG" ]]; then
-            docker tag ${REPO}:${COMMIT} ${REPO}:${TAG}
-        fi
-        push "$REPO:$TAG";
-    done;
+    DOCKER_REPO=${GROUP}/${REPO}
+    if [[ "$COMMIT" != "$TAG" ]]; then
+        echo "Tagging docker release"
+        docker tag ${DOCKER_REPO}:${COMMIT} ${DOCKER_REPO}:${TAG}
+    fi
+    push "$DOCKER_REPO:$TAG";
 }
 
 # Push snapshot when in master


### PR DESCRIPTION
- removed the line that pushes for any commit
- changed Docker tag for pushes from the master branch. The pushed
  Docker tag now contains tag of form: "master-<8 char commit SHA>"
- the tag pusing remains the same.

Related to microservices-demo/microservices-demo#553